### PR TITLE
FastFeatureDetector changed in OpenCV 3.*

### DIFF
--- a/svo/src/feature_detection.cpp
+++ b/svo/src/feature_detection.cpp
@@ -73,10 +73,10 @@ void FastDetector::detect(
   {
     const int scale = (1<<L);
 
-    cv::FastFeatureDetector fast_detector = cv::FastFeatureDetector(20, true);
+    auto fast_detector = cv::FastFeatureDetector::create(20, true);
     vector<cv::KeyPoint> key_points;
 
-    fast_detector.detect(img_pyr[L], key_points);
+    fast_detector->detect(img_pyr[L], key_points);
 
     for(auto it=key_points.begin(), ite=key_points.end(); it!=ite; ++it)
     {


### PR DESCRIPTION
Starting with OpenCV 3.0, FastFeatureDetector can no longer be instantiated directly.
Instead, `cv::FastFeatureDetector::create` is used to create a pointer to a `cv::FastFeatureDetector` which can then be used.

I think it's fair to assume that we won't be using OpenCV<3.0, but if necessary, I can try to change it so that it accommodates both. 